### PR TITLE
feature: add sliding movement, run timer, and win popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
             <h1 style="margin-top: 450px">The Maze Game</h1>
             <p>A simple yet fun game to play when you're bored.</p>
             <p id="lifetimeScore" style="font-weight: bold">Lifetime Score: 0</p>
+            <p id="timer" style="font-weight: bold">Time: 0.0s</p>
         </header>
 
         <div class="game-container">
@@ -57,6 +58,15 @@
             </div>
             <button id="regenerateMaze" style="margin-top: 25px" title="Too hard? Regenerate the maze! Note that you will lose 1 point for that.">Regenerate Maze</button>
             <button id="aboutGame" onclick="window.location.href='src/html/about.html'" style="margin-top: 25px; margin-bottom: 200px">About</button>
+        </div>
+
+        <div id="winModal" class="modal-overlay">
+            <div class="modal-box">
+                <h2>🎉 You did it!</h2>
+                <p id="winMessage">You escaped the maze!</p>
+                <p id="winTime" class="win-time">0.0s</p>
+                <button id="playAgain">Play Again</button>
+            </div>
         </div>
 
         <script src="src/js/game.js"></script>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -159,3 +159,63 @@ header h2 {
     background-color: #ececec;
     border-radius: 8px;
 }
+
+.modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-overlay.show {
+    display: flex;
+}
+
+.modal-box {
+    background-color: #fff;
+    color: #000;
+    padding: 30px 40px;
+    border-radius: 16px;
+    text-align: center;
+    max-width: 90%;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+    animation: pop-in 0.25s ease-out;
+}
+
+@keyframes pop-in {
+    from { transform: scale(0.8); opacity: 0; }
+    to { transform: scale(1); opacity: 1; }
+}
+
+.modal-box h2 {
+    margin: 0 0 10px;
+    font-size: 1.8em;
+}
+
+.modal-box .win-time {
+    font-size: 2em;
+    font-weight: 600;
+    color: #2e7d32;
+    margin: 10px 0 20px;
+}
+
+.modal-box button {
+    font-family: "Poppins", sans-serif;
+    font-size: 16px;
+    background-color: #2e7d32;
+    color: #fff;
+    border: none;
+    padding: 10px 24px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.modal-box button:hover {
+    background-color: #1b5e20;
+}

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -86,22 +86,83 @@ function checkCollision(x, y) {
     return maze[y][x] === 1;
 }
 
-function movePlayer(dx, dy) {
+// --- Timer: starts on the first move ---
+let startTime = null;
+let timerStarted = false;
+let timerRaf = null;
+let gameWon = false;
+const timerEl = document.getElementById('timer');
+
+function formatTime(ms) {
+    return (ms / 1000).toFixed(1) + 's';
+}
+
+function startTimer() {
+    if (timerStarted) return;
+    timerStarted = true;
+    startTime = performance.now();
+    function tick() {
+        timerEl.innerText = 'Time: ' + formatTime(performance.now() - startTime);
+        timerRaf = requestAnimationFrame(tick);
+    }
+    tick();
+}
+
+// --- Sliding movement: one press glides until a wall (or the exit) ---
+let slideInterval = null;
+const SLIDE_MS = 35; // smaller = faster slide
+
+function stopSliding() {
+    if (slideInterval) {
+        clearInterval(slideInterval);
+        slideInterval = null;
+    }
+}
+
+function step(dx, dy) {
     const newX = player.x + dx;
     const newY = player.y + dy;
     if (newX >= 0 && newX < cols && newY >= 0 && newY < rows && !checkCollision(newX, newY)) {
         player.x = newX;
         player.y = newY;
+        return true;
     }
+    return false;
+}
+
+function slide(dx, dy) {
+    if (gameWon) return;
+    startTimer();
+    stopSliding();
+    // Move at least one cell immediately, then keep gliding.
+    if (!step(dx, dy)) return;
+    if (checkWin()) return;
+    slideInterval = setInterval(() => {
+        if (!step(dx, dy) || checkWin()) {
+            stopSliding();
+        }
+    }, SLIDE_MS);
 }
 
 function checkWin() {
     if (player.x === exit.x && player.y === exit.y) {
+        gameWon = true;
+        stopSliding();
+        cancelAnimationFrame(timerRaf);
+        const elapsed = startTime ? performance.now() - startTime : 0;
+
         localStorage.getItem('lifetimeScore') ? localStorage.setItem('lifetimeScore', parseInt(localStorage.getItem('lifetimeScore')) + 1) : localStorage.setItem('lifetimeScore', 1);
-        alert("Congratulations, you've escaped the maze! Now we dare you to do it again! FYI, your lifetime score is currently: " + localStorage.getItem('lifetimeScore'));
-        window.location.reload();
+
+        document.getElementById('winMessage').innerText =
+            "You escaped the maze! Lifetime score: " + localStorage.getItem('lifetimeScore');
+        document.getElementById('winTime').innerText = 'Your time: ' + formatTime(elapsed);
+        document.getElementById('winModal').classList.add('show');
+        return true;
     }
+    return false;
 }
+
+document.getElementById('playAgain').addEventListener('click', () => window.location.reload());
 
 function draw() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -116,26 +177,25 @@ draw();
 window.addEventListener('keydown', (e) => {
     switch(e.key) {
         case 'ArrowUp':
-            movePlayer(0, -1);
+            slide(0, -1);
             e.preventDefault();
             break;
         case 'ArrowDown':
-            movePlayer(0, 1);
+            slide(0, 1);
             e.preventDefault();
             break;
         case 'ArrowLeft':
-            movePlayer(-1, 0);
+            slide(-1, 0);
             e.preventDefault();
             break;
         case 'ArrowRight':
-            movePlayer(1, 0);
+            slide(1, 0);
             e.preventDefault();
             break;
     }
-    checkWin();
 });
 
-document.getElementById('moveUp').addEventListener('click', () => movePlayer(0, -1));
-document.getElementById('moveDown').addEventListener('click', () => movePlayer(0, 1));
-document.getElementById('moveLeft').addEventListener('click', () => movePlayer(-1, 0));
-document.getElementById('moveRight').addEventListener('click', () => movePlayer(1, 0));
+document.getElementById('moveUp').addEventListener('click', () => slide(0, -1));
+document.getElementById('moveDown').addEventListener('click', () => slide(0, 1));
+document.getElementById('moveLeft').addEventListener('click', () => slide(-1, 0));
+document.getElementById('moveRight').addEventListener('click', () => slide(1, 0));


### PR DESCRIPTION
Gameplay enhancements to the browser maze game:

- Sliding movement: a single arrow press now glides the player in that direction until it hits a wall or reaches the exit, instead of having to tap repeatedly. On-screen buttons use the same behavior.
- Run timer: a live "Time: X.Xs" readout starts on the player's first move and stops on win, using performance.now().
- Win popup: reaching the exit shows a styled modal with the final time, lifetime score, and a Play Again button, replacing the old alert().