### PR TITLE
feat: partial hints, confirmation modal, and pre-run action lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@
 - **Achievements System**: 8 achievements to unlock
 - **Sound Effects**: Optional audio feedback
 - **Themes**: 10 visual themes (Daylight, Midnight, Neon, Forest, Sunset, Ocean, Dracula, Mono, Candy, Volcano)
-- **Touch Controls**: Swipe to move on mobile
+- **Touch Controls**: Swipe directly on the maze to move (plus an on-screen D-pad)
 - **Fully Responsive**: Presentable and playable from desktop down to small
-  phones (~360px) — swipe + on-screen D-pad, stacked layout, scrollable tables
+  phones (~360px) — swipe on the maze + on-screen D-pad, stacked layout, scrollable tables
 
 ### 🌐 Multiplayer (backend-ready)
 
@@ -174,7 +174,7 @@
 | 📊 Leaderboards          | Global rankings with timeframe filtering    |
 | 👤 Accounts & Stats      | Sign in to track level, win rate, streaks   |
 | 🎨 Themes                | 10 themes (Dracula, Sunset, Ocean, Neon, …) |
-| 📱 Touch                 | Swipe controls on mobile                    |
+| 📱 Touch                 | Swipe on the maze (or D-pad) on mobile      |
 | 🔊 Sound                 | Optional sound effects                      |
 | ⏸️ Pause                 | Pause and resume anytime                    |
 
@@ -275,15 +275,15 @@ the scripts load (or in the console).
 #### Controls
 
 - **Arrow Keys** or **WASD** - Move your character
-- **Swipe** - Move on touch devices
+- **Swipe on the maze** - Move on touch devices (swipe directly over the maze board)
 - **P** - Pause/Resume game
 - **H** - Use hint (costs points)
 - **R** - Generate a new maze
-- **On-screen buttons** - Alternative controls
+- **On-screen D-pad** - Alternative touch controls
 
 > [!NOTE]
 > On phones the maze and controls sit at the top with stats below, and you can
-> play entirely with swipes or the on-screen D-pad.
+> play entirely by swiping on the maze or using the on-screen D-pad.
 
 #### Objective
 

--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
           </div>
           <div class="stat-item"><span class="stat-label">Moves</span><span class="stat-value" id="moves">0</span></div>
           <div class="stat-item">
-            <span class="stat-label">Hints used</span><span class="stat-value" id="hints">0</span>
+            <span class="stat-label">Hints</span><span class="stat-value" id="hints">0 / 5</span>
           </div>
         </section>
 
@@ -384,13 +384,13 @@
                 </svg>
               </button>
             </div>
-            <p class="control-hint">Arrow keys / WASD · swipe on touch</p>
+            <p class="control-hint">Arrow keys / WASD · swipe on the maze · or tap the arrows above</p>
           </div>
 
           <div class="control-group reveal" style="--d: 4">
             <h4>Actions</h4>
             <div class="action-controls">
-              <button id="pauseGame" class="action-btn pause-btn" title="Pause (P)">
+              <button id="pauseGame" class="action-btn pause-btn" title="Pause (P)" disabled>
                 <span class="btn-ico">
                   <svg class="ico-pause" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                     <rect x="6" y="5" width="4" height="14" rx="1.2" />
@@ -402,7 +402,7 @@
                 </span>
                 <span class="btn-label">Pause</span>
               </button>
-              <button id="useHint" class="action-btn hint-btn" title="Show Hint (H)">
+              <button id="useHint" class="action-btn hint-btn" title="Show Hint (H)" disabled>
                 <span class="btn-ico">
                   <svg
                     viewBox="0 0 24 24"
@@ -420,7 +420,7 @@
                 </span>
                 <span class="btn-label">Hint</span>
               </button>
-              <button id="regenerateMaze" class="action-btn regen-btn" title="New Maze (R)">
+              <button id="regenerateMaze" class="action-btn regen-btn" title="New Maze (R)" disabled>
                 <span class="btn-ico">
                   <svg
                     viewBox="0 0 24 24"
@@ -444,6 +444,21 @@
           </div>
         </div>
       </main>
+    </div>
+
+    <!-- Hint Confirmation Modal -->
+    <div id="hintModal" class="modal-overlay" role="dialog" aria-labelledby="hintModalTitle" aria-modal="true">
+      <div class="modal-box hint-modal-box">
+        <span class="win-badge">Hint</span>
+        <h2 id="hintModalTitle">Use a hint?</h2>
+        <p id="hintModalText" class="modal-sub hint-modal-text">
+          This lights up the next few steps toward the exit — not the whole path.
+        </p>
+        <div class="hint-actions">
+          <button id="hintConfirm" type="button" class="auth-submit">Use hint</button>
+          <button id="hintCancel" type="button" class="ghost-btn">Cancel</button>
+        </div>
+      </div>
     </div>
 
     <!-- Win Modal -->
@@ -504,16 +519,18 @@
             <h3>Controls</h3>
             <ul>
               <li><strong>Arrow keys</strong> or <strong>WASD</strong> - move</li>
-              <li><strong>Swipe</strong> - move on touch devices</li>
+              <li><strong>Swipe on the maze</strong> - move on touch devices (or use the on-screen D-pad)</li>
               <li><strong>P</strong> - pause / resume</li>
-              <li><strong>H</strong> - hint (costs points)</li>
+              <li><strong>H</strong> - hint (shows a few steps ahead; costs points; limited per run)</li>
               <li><strong>R</strong> - new maze</li>
             </ul>
           </section>
           <section>
             <h3>Scoring</h3>
             <ul>
-              <li>Base score 100, reduced by time, moves, and hints</li>
+              <li>Base score 100, reduced by time, moves, and hints used</li>
+              <li>Each hint reveals only the next few cells — not the full path</li>
+              <li>Hint allowance scales with difficulty (e.g. Medium: 5 hints max)</li>
               <li>Higher difficulty multiplies your score</li>
               <li>Compete on the global leaderboard</li>
             </ul>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -778,6 +778,50 @@ kbd {
 .action-btn:active {
   transform: translateY(0);
 }
+.action-controls.is-pre-run {
+  position: relative;
+}
+.action-controls.is-pre-run::after {
+  content: "Press Play to unlock";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--line) 90%, transparent);
+  border-radius: var(--r-btn);
+  pointer-events: none;
+}
+.action-btn.is-locked,
+.action-btn:disabled {
+  cursor: not-allowed !important;
+  pointer-events: none;
+  opacity: 0.28;
+  filter: grayscale(1);
+  transform: none !important;
+  box-shadow: none !important;
+  color: var(--muted) !important;
+  background: color-mix(in srgb, var(--muted) 6%, var(--surface-2)) !important;
+  border-color: color-mix(in srgb, var(--line) 70%, transparent) !important;
+}
+.action-btn.is-locked .btn-ico svg,
+.action-btn:disabled .btn-ico svg {
+  opacity: 0.55;
+}
+.action-btn.is-locked:hover,
+.action-btn.is-locked:active,
+.action-btn:disabled:hover,
+.action-btn:disabled:active {
+  transform: none !important;
+  box-shadow: none !important;
+  background: color-mix(in srgb, var(--muted) 6%, var(--surface-2)) !important;
+}
 /* Pause/Play icon swap (selectors specific enough to beat .btn-ico svg) */
 .action-btn .btn-ico .ico-play {
   display: none;
@@ -909,6 +953,24 @@ kbd {
   color: var(--text);
   font-size: 1.1rem;
 }
+.hint-modal-box {
+  width: 420px;
+}
+.hint-modal-text {
+  text-align: left;
+  margin-bottom: 1.5rem;
+  line-height: 1.55;
+}
+.hint-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+.hint-actions .auth-submit,
+.hint-actions .ghost-btn {
+  width: 100%;
+}
+
 #playAgain {
   width: 100%;
   font-family: var(--font-ui);

--- a/src/html/about.html
+++ b/src/html/about.html
@@ -585,7 +585,10 @@
           </div>
           <div class="ab-step">
             <h3>Stuck? Get a hint</h3>
-            <p>An A* hint lights the next step toward the exit - handy, but it costs you points.</p>
+            <p>
+              Press H for a short A* nudge — only the next few cells light up, not the full path. Each hint costs points
+              and you get a limited number per run (more on harder difficulties). You'll confirm before one is spent.
+            </p>
             <div class="ab-keys">
               <span class="ab-key">H</span><span class="ab-key">P&nbsp;pause</span
               ><span class="ab-key">R&nbsp;new</span>
@@ -615,7 +618,7 @@
           <div class="ab-card">
             <span class="ab-ico">💡</span>
             <h3>A* hints</h3>
-            <p>Optimal next-step guidance when you're lost, computed with A* pathfinding.</p>
+            <p>Partial-path guidance when you're lost — a few steps ahead via A*, with a per-run cap and point cost.</p>
           </div>
           <div class="ab-card">
             <span class="ab-ico">🏆</span>
@@ -635,7 +638,7 @@
           <div class="ab-card">
             <span class="ab-ico">📱</span>
             <h3>Plays anywhere</h3>
-            <p>Swipe or an on-screen D-pad on phones, keyboard on desktop. Installable as a PWA.</p>
+            <p>Swipe on the maze (or use the on-screen D-pad) on phones, keyboard on desktop. Installable as a PWA.</p>
           </div>
           <div class="ab-card">
             <span class="ab-ico">🌍</span>
@@ -688,6 +691,8 @@
                 <th>Grid</th>
                 <th>Multiplier</th>
                 <th>Hint cost</th>
+                <th>Max hints</th>
+                <th>Steps shown</th>
               </tr>
             </thead>
             <tbody>
@@ -696,24 +701,32 @@
                 <td>11 × 15</td>
                 <td class="mono">1.0×</td>
                 <td class="mono">5 pts</td>
+                <td class="mono">3</td>
+                <td class="mono">3</td>
               </tr>
               <tr>
                 <td>Medium</td>
                 <td>15 × 21</td>
                 <td class="mono">1.5×</td>
                 <td class="mono">10 pts</td>
+                <td class="mono">5</td>
+                <td class="mono">4</td>
               </tr>
               <tr>
                 <td>Hard</td>
                 <td>21 × 31</td>
                 <td class="mono">2.0×</td>
                 <td class="mono">15 pts</td>
+                <td class="mono">7</td>
+                <td class="mono">5</td>
               </tr>
               <tr>
                 <td>Expert</td>
                 <td>25 × 35</td>
                 <td class="mono">3.0×</td>
                 <td class="mono">20 pts</td>
+                <td class="mono">9</td>
+                <td class="mono">6</td>
               </tr>
             </tbody>
           </table>
@@ -785,8 +798,8 @@
           <details>
             <summary>Does it work on mobile?</summary>
             <p>
-              Fully. Swipe to move or use the on-screen D-pad, the layout stacks for small screens, and you can install
-              it as a PWA for an app-like, offline-capable experience.
+              Fully. Swipe on the maze to move (or use the on-screen D-pad), the layout stacks for small screens, and
+              you can install it as a PWA for an app-like, offline-capable experience.
             </p>
           </details>
           <details>

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -49,11 +49,13 @@ class MazeGame {
 
     // Difficulty configurations (logical dimensions are normalised to odd
     // numbers in buildMaze so the bottom-right exit is always reachable).
+    // hintSteps = how many cells ahead a hint reveals (a nudge, not the answer).
+    // maxHints  = how many hints are allowed for the whole run.
     this.difficultyConfig = {
-      easy: { rows: 11, cols: 15, hintCost: 5, mult: 1 },
-      medium: { rows: 15, cols: 21, hintCost: 10, mult: 1.5 },
-      hard: { rows: 21, cols: 31, hintCost: 15, mult: 2 },
-      expert: { rows: 25, cols: 35, hintCost: 20, mult: 3 },
+      easy: { rows: 11, cols: 15, hintCost: 5, mult: 1, hintSteps: 3, maxHints: 3 },
+      medium: { rows: 15, cols: 21, hintCost: 10, mult: 1.5, hintSteps: 4, maxHints: 5 },
+      hard: { rows: 21, cols: 31, hintCost: 15, mult: 2, hintSteps: 5, maxHints: 7 },
+      expert: { rows: 25, cols: 35, hintCost: 20, mult: 3, hintSteps: 6, maxHints: 9 },
     };
 
     // Canvas color palettes per theme
@@ -175,6 +177,8 @@ class MazeGame {
     this.cols = cfg.cols | 1;
     this.hintCost = cfg.hintCost;
     this.scoreMult = cfg.mult;
+    this.hintSteps = cfg.hintSteps;
+    this.maxHints = cfg.maxHints;
 
     const cell = Math.floor(Math.min(800 / this.cols, 600 / this.rows));
     this.cellSize = cell;
@@ -210,7 +214,9 @@ class MazeGame {
     this.gameSessionId = null;
     this.setText('timer', '00:00');
     this.setText('currentScore', '0');
+    this.closeHintModal();
     this.showStartOverlay();
+    this.updateHintUI();
   }
 
   // Player pressed Play: reshuffle the maze (so any peeking is moot), start the
@@ -225,10 +231,13 @@ class MazeGame {
     this.hintsUsed = 0;
     this.hintPath = [];
     this.showingHint = false;
+    this.paused = false;
+    this.won = false;
     this.started = true;
     this.gameStartTime = Date.now();
     this.hideStartOverlay();
     this.updateHUD();
+    this.syncActionButtons();
     this.startGameSession();
   }
 
@@ -288,6 +297,8 @@ class MazeGame {
     click('pauseGame', () => this.togglePause());
     click('useHint', () => this.showHint());
     click('regenerateMaze', () => this.regenerate());
+    click('hintConfirm', () => this.applyHint());
+    click('hintCancel', () => this.closeHintModal());
     click('playAgain', () => {
       this.hideWinModal();
       this.reset();
@@ -425,6 +436,7 @@ class MazeGame {
     if (this.paused) this.pausedAt = Date.now();
     else this.gameStartTime += Date.now() - this.pausedAt;
     this.setPauseButton(this.paused);
+    this.syncActionButtons();
   }
 
   // Swap the pause button's icon (via .paused class) + label without emojis.
@@ -438,22 +450,114 @@ class MazeGame {
 
   // ---- hints (A*) ----------------------------------------------------------
 
+  // Clicking Hint (or pressing H) asks for confirmation first — a hint costs
+  // points and you only get a few per run.
   showHint() {
     if (!this.started || this.paused || this.won || this.showingHint) return;
+    const remaining = this.maxHints - this.hintsUsed;
+    if (remaining <= 0) {
+      this.flashMessage('No hints left for this run.');
+      return;
+    }
+    if (this.currentScore() < this.hintCost) {
+      this.flashMessage(`Need ${this.hintCost} points for a hint.`);
+      return;
+    }
+    this.openHintModal(remaining);
+  }
+
+  openHintModal(remaining) {
+    const text = document.getElementById('hintModalText');
+    if (text) {
+      const noun = remaining === 1 ? 'hint' : 'hints';
+      text.innerHTML =
+        `This lights up the next <b>${this.hintSteps}</b> steps toward the exit — not the whole path. ` +
+        `It costs <b>${this.hintCost} pts</b>, and you have <b>${remaining}</b> ${noun} left this run.`;
+    }
+    document.getElementById('hintModal')?.classList.add('show');
+  }
+
+  closeHintModal() {
+    document.getElementById('hintModal')?.classList.remove('show');
+  }
+
+  // Confirmed: spend one hint and reveal only the next few steps.
+  applyHint() {
+    this.closeHintModal();
+    if (!this.started || this.paused || this.won || this.showingHint) return;
+    if (this.hintsUsed >= this.maxHints) {
+      this.flashMessage('No hints left for this run.');
+      return;
+    }
     if (this.currentScore() < this.hintCost) {
       this.flashMessage(`Need ${this.hintCost} points for a hint.`);
       return;
     }
     this.hintsUsed++;
     this.playSound('hint');
-    this.hintPath = this.findPath(this.player.x, this.player.y, this.exit.x, this.exit.y);
+    const full = this.findPath(this.player.x, this.player.y, this.exit.x, this.exit.y);
+    // A nudge, not the answer: current cell + the next `hintSteps` cells.
+    this.hintPath = full.slice(0, this.hintSteps + 1);
     this.showingHint = true;
+    this.scrollToMazeIfNeeded();
     window.dispatchEvent(new CustomEvent('hintUsed', { detail: { difficulty: this.difficulty } }));
     setTimeout(() => {
       this.showingHint = false;
       this.hintPath = [];
+      this.syncActionButtons();
     }, 3000);
-    this.setText('hints', this.hintsUsed);
+    this.updateHintUI();
+  }
+
+  // After confirming a hint, bring the maze into view if the player scrolled away.
+  scrollToMazeIfNeeded() {
+    const target = this.canvas?.closest('.game-canvas-container') || this.canvas;
+    if (!target) return;
+    const rect = target.getBoundingClientRect();
+    const vh = window.innerHeight || document.documentElement.clientHeight;
+    const visible = Math.max(0, Math.min(rect.bottom, vh) - Math.max(rect.top, 0));
+    if (visible / Math.max(rect.height, 1) < 0.45) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }
+
+  setBtnLocked(id, locked) {
+    const btn = document.getElementById(id);
+    if (!btn) return;
+    btn.classList.toggle('is-locked', locked);
+    if (locked) {
+      btn.disabled = true;
+      btn.setAttribute('aria-disabled', 'true');
+    } else {
+      btn.disabled = false;
+      btn.removeAttribute('disabled');
+      btn.removeAttribute('aria-disabled');
+    }
+  }
+
+  // Pause · Hint · New Maze — locked until Play; hint also locks when spent/paused.
+  syncActionButtons() {
+    const container = document.querySelector('.action-controls');
+    const preRun = !this.started;
+    container?.classList.toggle('is-pre-run', preRun);
+
+    const runLive = this.started && !this.won;
+    this.setBtnLocked('pauseGame', !runLive);
+    this.setBtnLocked('regenerateMaze', !runLive);
+
+    const hintLocked =
+      !runLive ||
+      this.paused ||
+      this.showingHint ||
+      (this.maxHints != null && this.hintsUsed >= this.maxHints);
+    this.setBtnLocked('useHint', hintLocked);
+  }
+
+  updateHintUI() {
+    if (this.maxHints != null) {
+      this.setText('hints', `${this.hintsUsed} / ${this.maxHints}`);
+    }
+    this.syncActionButtons();
   }
 
   findPath(sx, sy, ex, ey) {
@@ -558,6 +662,7 @@ class MazeGame {
   }
 
   regenerate() {
+    if (!this.started) return;
     if (this.won) {
       this.reset();
       return;
@@ -816,11 +921,11 @@ class MazeGame {
   updateHUD() {
     this.setText('difficulty', this.difficulty.toUpperCase());
     this.setText('moves', this.moves);
-    this.setText('hints', this.hintsUsed);
     this.setText('currentScore', this.currentScore());
     this.setText('lifetimeScore', this.stats.totalScore);
     this.setText('gamesWon', this.stats.gamesWon);
     this.setText('bestTime', this.formatTime(this.stats.bestTime));
+    this.updateHintUI();
   }
 
   formatTime(ms) {


### PR DESCRIPTION
## Summary
- Rework hints to show only the next few path cells (not the full route), with per-difficulty `maxHints` / `hintSteps`, point cost, and a confirmation modal before spending one
- Lock Pause, Hint, and New Maze until the player presses Play, with clearer disabled styling and a pre-run overlay on the action group
- Scroll the maze into view after confirming a hint when it is mostly off-screen (mobile-friendly)
- Update help copy, about page difficulty table, and README touch-control wording

## Test plan
- [ ] Load the game — Pause / Hint / New Maze should look locked and be non-interactive before Play
- [ ] Press Play — all three action buttons should unlock
- [ ] Use Hint — confirm modal appears; cancel keeps hint count/score unchanged
- [ ] Confirm hint — partial yellow path shows for ~3s, HUD shows `used / max`, score drops by hint cost
- [ ] On mobile/narrow viewport, scroll down to controls, confirm hint — page scrolls back to the maze
- [ ] Exhaust hint allowance — Hint button disables; Pause and New Maze still work
- [ ] Win and play again — action buttons lock again until the next Play press


Made with [Cursor](https://cursor.com)